### PR TITLE
Support adaptive launcher icons

### DIFF
--- a/modules-ui/resources/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/modules-ui/resources/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/modules-ui/resources/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/modules-ui/resources/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
### Type
- [ ] Feature
- [ ] Bug
- [x] Enhancement
- [ ] Chore

### Status
- [ ] Work In Progress
- [x] Completed
- [ ] In Review

### Checks
- [x] I have run `./gradlew build` or build and it passed successfully
- [x] I have run `./gradlew check` or tests and all have passed successfully
- [x] I have tested the app on a physical device and it works as intended

### Current Behaviour
> what is the current behaviour of what was being worked on

Launcher icon could not adapt to the theme colors
![Launcher](https://github.com/user-attachments/assets/15e9db0d-ac02-4d66-95d9-d9c1d474fbc7)

### Intended Behaviour
> what is the intended behaviour of what was being worked on

Launcher icons can now be themed adaptively
![Launcher](https://github.com/user-attachments/assets/8c80aa7e-a9ed-405b-8f6d-6276b3c42c35)

### Closes Issues
> issue number of what was being worked on (__if necessary__)

Closes #174

### Notes
> additional information of what was being worked on (__if necessary__)

None

### Screenshot
> an image of what was being worked on (__if necessary__)

None