### PR TITLE
fixes crash on screens collecting paging flow

### DIFF
--- a/modules-features/leaderboard/src/main/java/com/bizilabs/streeek/feature/leaderboard/LeaderboardScreenModel.kt
+++ b/modules-features/leaderboard/src/main/java/com/bizilabs/streeek/feature/leaderboard/LeaderboardScreenModel.kt
@@ -1,14 +1,15 @@
 package com.bizilabs.streeek.feature.leaderboard
 
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.bizilabs.streeek.lib.common.components.paging.getPagingDataLoading
 import com.bizilabs.streeek.lib.domain.models.LeaderboardAccountDomain
 import com.bizilabs.streeek.lib.domain.models.LeaderboardDomain
 import com.bizilabs.streeek.lib.domain.repositories.LeaderboardRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -31,7 +32,7 @@ class LeaderboardScreenModel(
     private val repository: LeaderboardRepository,
 ) : StateScreenModel<LeaderboardScreenState>(LeaderboardScreenState()) {
     private var _pages = MutableStateFlow(getPagingDataLoading<LeaderboardAccountDomain>())
-    val pages: StateFlow<PagingData<LeaderboardAccountDomain>> = _pages.asStateFlow()
+    val pages: Flow<PagingData<LeaderboardAccountDomain>> = _pages.asStateFlow().cachedIn(screenModelScope)
 
     fun onValueChange(name: String) {
         if (state.value.hasPassedNavigationArgument) return

--- a/modules-features/team/src/main/java/com/bizilabs/streeek/feature/team/TeamScreenModel.kt
+++ b/modules-features/team/src/main/java/com/bizilabs/streeek/feature/team/TeamScreenModel.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.bizilabs.streeek.lib.common.components.paging.getPagingDataLoading
@@ -35,7 +36,6 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -186,7 +186,7 @@ class TeamScreenModel(
     private val teamRequestRepository: TeamRequestRepository,
 ) : StateScreenModel<TeamScreenState>(TeamScreenState()) {
     private var _pages = MutableStateFlow(getPagingDataLoading<TeamMemberDomain>())
-    val pages: StateFlow<PagingData<TeamMemberDomain>> = _pages.asStateFlow()
+    val pages: Flow<PagingData<TeamMemberDomain>> = _pages.asStateFlow().cachedIn(screenModelScope)
 
     private var _requests: Flow<PagingData<TeamAccountJoinRequestDomain>> =
         MutableStateFlow(getPagingDataLoading<TeamAccountJoinRequestDomain>()).asStateFlow()


### PR DESCRIPTION
### Type
- [ ] Feature
- [x] Bug
- [ ] Enhancement
- [ ] Chore

### Status
- [ ] Work In Progress
- [x] Completed
- [ ] In Review

### Checks
- [x] I have run `./gradlew build` or build and it passed successfully
- [x] I have run `./gradlew check` or tests and all have passed successfully
- [x] I have tested the app on a physical device and it works as intended

### Previous Behaviour
> what is the current behaviour of what was being worked on

The app was crashing when changing modes in `LeaderboardScreen` and `TeamScreen`

### Current Behaviour
> what is the current behaviour of what was being worked on

The should not crash and only collects the paging flow once

### Intended Behaviour
> what is the intended behaviour of what was being worked on

Same as intended

### Closes Issues
> issue number of what was being worked on (__if necessary__)

closes #193

[//]: # (`fixes #1` or `closes #1`)

### Notes
> additional information of what was being worked on (__if necessary__)

None

### Screenshot
> an image of what was being worked on (__if necessary__)

None