### PR TITLE
Enhancement - Enable panel settings API for network connectivity restoration

### DIFF
--- a/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
+++ b/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
@@ -54,14 +54,14 @@ private fun getNetworkData(isNetworkConnected: Boolean) =
         )
     }
 
-
 fun Context.openNetworkSettings() {
-    val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        Intent(Settings.Panel.ACTION_INTERNET_CONNECTIVITY)
-    } else {
-        // Fallback for older Android versions
-        Intent(Settings.ACTION_WIRELESS_SETTINGS)
-    }
+    val intent =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Intent(Settings.Panel.ACTION_INTERNET_CONNECTIVITY)
+        } else {
+            // Fallback for older Android versions
+            Intent(Settings.ACTION_WIRELESS_SETTINGS)
+        }
     if (this is AppCompatActivity) {
         startActivityForResult(intent, 100)
     } else {

--- a/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
+++ b/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
@@ -2,7 +2,9 @@ package com.bizilabs.streeek.lib.design.components
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -52,9 +54,21 @@ private fun getNetworkData(isNetworkConnected: Boolean) =
         )
     }
 
+
 fun Context.openNetworkSettings() {
-    val intent = Intent(Settings.ACTION_WIFI_SETTINGS)
-    startActivity(intent)
+    val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        // Modern approach for Android 10+ (Q and above)
+        Intent(Settings.Panel.ACTION_INTERNET_CONNECTIVITY)
+    } else {
+        // Fallback for older Android versions
+        Intent(Settings.ACTION_WIRELESS_SETTINGS)
+    }
+
+    if (this is AppCompatActivity) {
+        startActivityForResult(intent, 100)
+    } else {
+        startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
 }
 
 @Composable

--- a/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
+++ b/modules-ui/design/src/main/kotlin/com/bizilabs/streeek/lib/design/components/SafiNetworkComponent.kt
@@ -57,13 +57,11 @@ private fun getNetworkData(isNetworkConnected: Boolean) =
 
 fun Context.openNetworkSettings() {
     val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        // Modern approach for Android 10+ (Q and above)
         Intent(Settings.Panel.ACTION_INTERNET_CONNECTIVITY)
     } else {
         // Fallback for older Android versions
         Intent(Settings.ACTION_WIRELESS_SETTINGS)
     }
-
     if (this is AppCompatActivity) {
         startActivityForResult(intent, 100)
     } else {


### PR DESCRIPTION
### Type
- [ ] Feature
- [ ] Bug
- [x] Enhancement
- [ ] Chore

### Status
- [ ] Work In Progress
- [x] Completed
- [ ] In Review

### Checks
- [x] I have run `./gradlew build` or build and it passed successfully
- [x] I have run `./gradlew check` or tests and all have passed successfully
- [x] I have tested the app on a physical device and it works as intended

### Previous Behaviour

Previous Implementation opens WIFI Settings only.

### Current Behaviour
> what is the current behaviour of what was being worked on
App opens the Settings Panel API to display to the user Mobile, Wifi and NFC Toggles to enable them turn on or off internet connectivity.

### Intended Behaviour
> what is the intended behaviour of what was being worked on
App should allow user to enable connectivity for any of the available options on device.

### Closes Issues
> issue number of what was being worked on (__if necessary__)

Fixes #203 

[//]: # (`fixes #1` or `closes #1`)

### Notes
> additional information of what was being worked on (__if necessary__)

Handles compatibility for Later or earlier versions of Android.

### Screenshot
> an image of what was being worked on (__if necessary__)

![Screenshot_20250202_193026_Streeek Debug](https://github.com/user-attachments/assets/168bcff9-37d2-4ce4-99a7-c4a2a71a742b)
