### PR TITLE
adds app navigation via uri

### DIFF
--- a/modules-features/landing/src/main/java/com/bizilabs/streeek/feature/landing/IntentNavigation.kt
+++ b/modules-features/landing/src/main/java/com/bizilabs/streeek/feature/landing/IntentNavigation.kt
@@ -1,0 +1,72 @@
+package com.bizilabs.streeek.feature.landing
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import cafe.adriel.voyager.core.registry.rememberScreen
+import cafe.adriel.voyager.core.screen.Screen
+import com.bizilabs.streeek.lib.common.navigation.SharedScreen
+import com.bizilabs.streeek.lib.domain.models.notifications.asNotificationResult
+
+@Composable
+fun getNavigationDestinationFromURI(): List<Screen> {
+    val intent = (LocalContext.current as? ComponentActivity)?.intent ?: return emptyList()
+    val result = intent.asNotificationResult() ?: return emptyList()
+    val uri = result.uri
+    if (uri.isBlank()) return emptyList()
+    val map = uri.asIntentExtraArguments()
+    val action = map["action"]
+    if (action == null || !(action.equals("navigate", true))) return emptyList()
+    return getNavigationDestination(map = map)
+}
+
+private fun String.asIntentExtraArguments(): Map<String, String> {
+    val params =
+        replace("https://app.streeek.com/v1?", "")
+            .split("&")
+    val map = mutableMapOf<String, String>()
+    params.forEach {
+        val keyAndValue = it.split("=")
+        val key = keyAndValue.firstOrNull()
+        val value = keyAndValue.lastOrNull()
+        if (key != null && value != null) {
+            map[key] = value
+        }
+    }
+    return map
+}
+
+@Composable
+private fun getNavigationDestination(map: Map<String, String>): List<Screen> {
+    val destination = map["destination"] ?: return emptyList()
+    return when (destination) {
+        "NOTIFICATIONS" -> listOf(rememberScreen(SharedScreen.Tabs(tab = destination)))
+        "ACHIEVEMENTS" -> listOf(rememberScreen(SharedScreen.Tabs(tab = destination)))
+        "FEED" -> listOf(rememberScreen(SharedScreen.Tabs))
+        "LEADERBOARDS" -> {
+            val name = map["name"]?.uppercase()
+            if (name == null) {
+                listOf(rememberScreen(SharedScreen.Tabs(tab = destination)))
+            } else {
+                listOf(
+                    rememberScreen(SharedScreen.Tabs(tab = destination)),
+                    rememberScreen(SharedScreen.Leaderboard(name = name)),
+                )
+            }
+        }
+
+        "TEAMS" -> {
+            val teamId = map["teamId"]?.toLongOrNull()
+            if (teamId == null) {
+                listOf(rememberScreen(SharedScreen.Tabs(tab = destination)))
+            } else {
+                listOf(
+                    rememberScreen(SharedScreen.Tabs(tab = destination)),
+                    rememberScreen(SharedScreen.Team(teamId = teamId)),
+                )
+            }
+        }
+
+        else -> emptyList()
+    }
+}

--- a/modules-features/landing/src/main/java/com/bizilabs/streeek/feature/landing/LandingScreen.kt
+++ b/modules-features/landing/src/main/java/com/bizilabs/streeek/feature/landing/LandingScreen.kt
@@ -34,6 +34,7 @@ object LandingScreen : Screen {
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
 
+        val intentDestinations = getNavigationDestinationFromURI()
         val onBoardingScreen = rememberScreen(SharedScreen.OnBoarding)
         val authenticationScreen = rememberScreen(SharedScreen.Authentication)
         val setupScreen = rememberScreen(SharedScreen.Setup)
@@ -43,12 +44,16 @@ object LandingScreen : Screen {
         val state by screenModel.state.collectAsStateWithLifecycle()
 
         LandingScreenContent(state = state) { destination ->
-            when (destination) {
-                LandingScreenDestination.CURRENT -> Unit
-                LandingScreenDestination.AUTHENTICATE -> navigator.replace(authenticationScreen)
-                LandingScreenDestination.TABS -> navigator.replace(tabsScreen)
-                LandingScreenDestination.SETUP -> navigator.replace(setupScreen)
-                LandingScreenDestination.ONBOARDING -> navigator.replace(onBoardingScreen)
+            if (intentDestinations.isNotEmpty() && destination != LandingScreenDestination.AUTHENTICATE) {
+                navigator.replaceAll(intentDestinations)
+            } else {
+                when (destination) {
+                    LandingScreenDestination.CURRENT -> Unit
+                    LandingScreenDestination.AUTHENTICATE -> navigator.replace(authenticationScreen)
+                    LandingScreenDestination.TABS -> navigator.replace(tabsScreen)
+                    LandingScreenDestination.SETUP -> navigator.replace(setupScreen)
+                    LandingScreenDestination.ONBOARDING -> navigator.replace(onBoardingScreen)
+                }
             }
         }
     }
@@ -78,7 +83,10 @@ fun LandingScreenContent(
                 tint = MaterialTheme.colorScheme.onBackground,
             )
             LinearProgressIndicator(
-                modifier = Modifier.padding(16.dp).width(75.dp),
+                modifier =
+                    Modifier
+                        .padding(16.dp)
+                        .width(75.dp),
                 color = MaterialTheme.colorScheme.onBackground,
             )
         }

--- a/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreen.kt
+++ b/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreen.kt
@@ -33,14 +33,16 @@ import com.bizilabs.streeek.lib.common.navigation.SharedScreen
 
 val featureTabs =
     screenModule {
-        register<SharedScreen.Tabs> { TabsScreen }
+        register<SharedScreen.Tabs> { params -> TabsScreen(tab = params.tab) }
+        register<SharedScreen.Tabs.Companion> { params -> TabsScreen(tab = params.tab) }
     }
 
-object TabsScreen : Screen {
+open class TabsScreen(val tab: String) : Screen {
     @Composable
     override fun Content() {
         val activity = LocalContext.current as Activity
         val screenModel: TabsScreenModel = getScreenModel()
+        screenModel.setTabFromNavigation(value = tab)
         val state by screenModel.state.collectAsStateWithLifecycle()
 
         BackHandler(enabled = true) {

--- a/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreenModel.kt
+++ b/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreenModel.kt
@@ -19,6 +19,7 @@ import com.bizilabs.streeek.feature.tabs.screens.feed.FeedModule
 import com.bizilabs.streeek.feature.tabs.screens.leaderboard.LeaderboardModule
 import com.bizilabs.streeek.feature.tabs.screens.notifications.ModuleNotifications
 import com.bizilabs.streeek.feature.tabs.screens.teams.TeamsListModule
+import com.bizilabs.streeek.lib.domain.helpers.tryOrNull
 import com.bizilabs.streeek.lib.domain.workers.startPeriodicAccountSyncWork
 import com.bizilabs.streeek.lib.domain.workers.startPeriodicDailySyncContributionsWork
 import com.bizilabs.streeek.lib.domain.workers.startPeriodicLeaderboardSyncWork
@@ -72,6 +73,7 @@ enum class Tabs {
 }
 
 data class TabsScreenState(
+    val hasSetTabFromNavigation: Boolean = false,
     val tab: Tabs = Tabs.FEED,
     val tabs: List<Tabs> = Tabs.entries.toList(),
 )
@@ -92,6 +94,12 @@ class TabsScreenModel(
             startPeriodicLeaderboardSyncWork()
             startPeriodicDailySyncContributionsWork()
         }
+    }
+
+    fun setTabFromNavigation(value: String) {
+        val tab = tryOrNull { Tabs.valueOf(value) } ?: return
+        if (state.value.hasSetTabFromNavigation) return
+        mutableState.update { it.copy(hasSetTabFromNavigation = true, tab = tab) }
     }
 
     fun onValueChangeTab(tab: Tabs) {

--- a/modules-ui/common/src/main/kotlin/com/bizilabs/streeek/lib/common/navigation/SharedScreen.kt
+++ b/modules-ui/common/src/main/kotlin/com/bizilabs/streeek/lib/common/navigation/SharedScreen.kt
@@ -9,7 +9,9 @@ sealed class SharedScreen : ScreenProvider {
 
     object Authentication : SharedScreen()
 
-    object Tabs : SharedScreen()
+    open class Tabs(val tab: String = "FEED") : SharedScreen() {
+        companion object : Tabs()
+    }
 
     object Setup : SharedScreen()
 

--- a/modules-ui/presentation/src/main/kotlin/com/bizilabs/streeek/lib/presentation/MainActivity.kt
+++ b/modules-ui/presentation/src/main/kotlin/com/bizilabs/streeek/lib/presentation/MainActivity.kt
@@ -35,10 +35,7 @@ class MainActivity : BaseActivity() {
                     isNetworkConnected = state.hasNetworkConnection,
                     barColors = state.barColors,
                 ) {
-                    MainNavigation(
-                        intent = intent,
-                        onValueChangeBarColors = viewModel::onValueChangeBarColors,
-                    )
+                    MainNavigation(onValueChangeBarColors = viewModel::onValueChangeBarColors)
                 }
             }
         }

--- a/modules-ui/presentation/src/main/kotlin/com/bizilabs/streeek/lib/presentation/MainNavigation.kt
+++ b/modules-ui/presentation/src/main/kotlin/com/bizilabs/streeek/lib/presentation/MainNavigation.kt
@@ -1,6 +1,5 @@
 package com.bizilabs.streeek.lib.presentation
 
-import android.content.Intent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import cafe.adriel.voyager.core.screen.Screen
@@ -9,15 +8,10 @@ import com.bizilabs.streeek.feature.landing.LandingScreen
 import com.bizilabs.streeek.feature.tabs.TabsScreen
 import com.bizilabs.streeek.lib.design.helpers.SafiBarColors
 import com.bizilabs.streeek.lib.domain.models.notifications.NotificationResult
-import com.bizilabs.streeek.lib.domain.models.notifications.asNotificationResult
 
 @Composable
-fun MainNavigation(
-    intent: Intent,
-    onValueChangeBarColors: (SafiBarColors) -> Unit,
-) {
-    val destination = intent.asNotificationResult().asNavigationDestination()
-    Navigator(destination) {
+fun MainNavigation(onValueChangeBarColors: (SafiBarColors) -> Unit) {
+    Navigator(LandingScreen) {
         val screen = it.lastItem
         onValueChangeBarColors(screen.getBarColors())
         screen.Content()


### PR DESCRIPTION
### Type
- [ ] Feature
- [ ] Bug
- [x] Enhancement
- [ ] Chore

### Status
- [ ] Work In Progress
- [x] Completed
- [ ] In Review

### Checks
- [x] I have run `./gradlew build` or build and it passed successfully
- [x] I have run `./gradlew check` or tests and all have passed successfully
- [x] I have tested the app on a physical device and it works as intended

### Previous Behaviour
> what is the current behaviour of what was being worked on

No navigation parsing via intent

### Current Behaviour
> what is the current behaviour of what was being worked on

App can navigate to a specific destination via a uri.
Example : 
`https://app.streeek.com/v1?action=navigate&destination=TEAMS&teamId=1` > navigates to the team screen with the id provided
`https://app.streeek.com/v1?action=navigate&destination=LEADERBOARDS&name=weekly` > navigates to the leaderboard screen with the `name` provided

### Closes Issues
> issue number of what was being worked on (__if necessary__)

None

[//]: # (`fixes #1` or `closes #1`)

### Notes
> additional information of what was being worked on (__if necessary__)

If you'd like to test this out use the examples above in the `IntentNavigation.kt` file commenting out line `13` and `14`, replace `val uri = result.uri` with `val uri = {EXAMPLE_URI_ABOVE}`

### Screenshot
> an image of what was being worked on (__if necessary__)

None