### PR TITLE
Moves the achievements destination to the far right

### DIFF
--- a/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreen.kt
+++ b/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreen.kt
@@ -116,8 +116,8 @@ fun TabsScreenContent(
                         )
 
                     Tabs.TEAMS -> TeamsListScreen
-                    Tabs.ACHIEVEMENTS -> AchievementsScreen
                     Tabs.NOTIFICATIONS -> NotificationsScreen
+                    Tabs.ACHIEVEMENTS -> AchievementsScreen
                 }
             screen.Content()
         }

--- a/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreenModel.kt
+++ b/modules-features/tabs/src/main/java/com/bizilabs/streeek/feature/tabs/TabsScreenModel.kt
@@ -48,8 +48,8 @@ enum class Tabs {
     LEADERBOARDS,
     TEAMS,
     FEED,
-    ACHIEVEMENTS,
     NOTIFICATIONS,
+    ACHIEVEMENTS,
     ;
 
     val icon: Pair<ImageVector, ImageVector>
@@ -58,8 +58,8 @@ enum class Tabs {
                 FEED -> Pair(Icons.Outlined.Explore, Icons.Rounded.Explore)
                 LEADERBOARDS -> Pair(Icons.Outlined.Leaderboard, Icons.Rounded.Leaderboard)
                 TEAMS -> Pair(Icons.Outlined.PeopleAlt, Icons.Rounded.PeopleAlt)
-                ACHIEVEMENTS -> Pair(Icons.Outlined.EmojiEvents, Icons.Rounded.EmojiEvents)
                 NOTIFICATIONS -> Pair(Icons.Outlined.Notifications, Icons.Rounded.Notifications)
+                ACHIEVEMENTS -> Pair(Icons.Outlined.EmojiEvents, Icons.Rounded.EmojiEvents)
             }
 
     val label: String
@@ -68,8 +68,8 @@ enum class Tabs {
                 FEED -> "Feed"
                 LEADERBOARDS -> "Leaderboard"
                 TEAMS -> "Teams"
-                ACHIEVEMENTS -> "Achievements"
                 NOTIFICATIONS -> "Notifications"
+                ACHIEVEMENTS -> "Achievements"
             }
 }
 


### PR DESCRIPTION
### Type
- [ ] Feature
- [ ] Bug
- [x] Enhancement
- [ ] Chore

### Status
- [ ] Work In Progress
- [x] Completed
- [ ] In Review

### Checks
- [x] I have run `./gradlew build` or build and it passed successfully
- [ ] I have run `./gradlew check` or tests and all have passed successfully
- [x] I have tested the app on a physical device and it works as intended

### Previous Behaviour
> The achievements destination is the second last item

None

### Current Behaviour
> The achievements destination is the last item making it easier to match user behavior and hoping to impove the settings icon accessibility. 

<img src="https://github.com/user-attachments/assets/75c62a27-f517-4ca4-a0b5-98a521bb8043" alt="Screenshot_20250225_154046" width="300"/>


None

### Intended Behaviour
> what is the intended behaviour of what was being worked on

None

### Closes Issues
> issue number of what was being worked on (__if necessary__)

None

[//]: # (`fixes #1` or `closes #1`)

### Notes
> additional information of what was being worked on (__if necessary__)

None

### Screenshot
> an image of what was being worked on (__if necessary__)

None