### PR TITLE
[migration] : adds and configures shared remote module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     alias(libs.plugins.firebase.crashlytics) apply false
     // others
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.buildconfig)
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@ plugins {
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     // others
+    alias(libs.plugins.buildconfig) apply false
     alias(libs.plugins.ktlint)
-    alias(libs.plugins.buildconfig)
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,9 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
+    alias(libs.plugins.kotlin.compose.multiplatform) apply false
     // google
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -285,4 +285,7 @@ paging = ["androidx-paging-runtime", "androidx-paging-compose"]
 kmp-ktor = [
     "ktor-client-core", "ktor-logging", "ktor-content-negotiation", "ktor-serialization-json",
 ]
-kmp-koin = ["koin-core", "koin-core-coroutines",]
+kmp-koin = [
+    "koin-core", "koin-core-coroutines", "ktor-logging", "ktor-content-negotiation",
+    "ktor-serialization-json"
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ updater = "2.1.0"
 google-inapp-reviews-ktx = "2.0.2"
 rich-text-editor = "1.0.0-rc10"
 buildconfig = "5.5.1"
+napier = "2.7.1"
 
 [libraries]
 # androidx
@@ -228,6 +229,7 @@ updater = { module = "com.google.android.play:app-update", version.ref = "update
 richtexteditor = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "rich-text-editor"}
 firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx", version.ref = "firebase-messaging-ktx" }
 google-firebase-database = { group = "com.google.firebase", name = "firebase-database", version.ref = "firebase-database" }
+napier = { group = "io.github.aakira", name="napier", version.ref = "napier" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle-plugin-android" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,12 @@ kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.7.3"
 kotlinx-datetime = "0.6.0"
-ktor = "3.0.0"
+ktor = "3.1.1"
+
+# android sdk
+android-sdk-compile = "35"
+android-sdk-min = "28"
+android-sdk-target = "34"
 
 # android libraries
 androidx-splash-screen = "1.0.1"
@@ -32,7 +37,8 @@ androidx-activity = "1.9.2"
 compose-bom = "2024.11.00"
 compose-tv-foundation = "1.0.0-alpha11"
 compose-tv-material = "1.0.0"
-androidx-activity-compose = "1.9.3"
+androidx-activity-compose = "1.10.1"
+compose-multiplatform = "1.7.0"
 
 # google libraries
 firebase_bom = "33.7.0"
@@ -136,11 +142,13 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 # serialization
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 # coroutines
-kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 # ktor
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
@@ -194,7 +202,6 @@ media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 # gradle plugins
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "gradle-plugin-android" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
 # saket
 saket-swipe = { module = "me.saket.swipe:swipe", version.ref = "saket-swipe" }
@@ -223,14 +230,17 @@ google-firebase-database = { group = "com.google.firebase", name = "firebase-dat
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle-plugin-android" }
 android-library = { id = "com.android.library", version.ref = "gradle-plugin-android" }
+
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "gradle-plugin-firebase-crashlytics" }
 firebase-performance = { id = "com.google.firebase.firebase-perf", version.ref = "gradle-plugin-firebase-performance" }
 google-services = { id = "com.google.gms.google-services", version.ref = "gradle-plugin-google-services" }
-realm = { id = "io.realm.kotlin", version.ref = "realm" }
-kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 [bundles]
@@ -267,3 +277,7 @@ supabase = [
     "supabase-storage", "supabase-functions"
 ]
 paging = ["androidx-paging-runtime", "androidx-paging-compose"]
+kmp-ktor = [
+    "ktor-client-core", "ktor-logging", "ktor-content-negotiation", "ktor-serialization-json",
+]
+kmp-koin = ["koin-core", "koin-core-coroutines",]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ koin-core-coroutines = { module = "io.insert-koin:koin-core-coroutines" }
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager" }
 koin-test = { module = "io.insert-koin:koin-test" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4" }
+koin-test-junit5 = { module = "io.insert-koin:koin-test-junit5" }
 
 # androidx-work-manager
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work-manager" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 # gradle plugins
+buildkonfig-gradle-plugin = "0.17.0"
 gradle-plugin-android = "8.2.2"
 gradle-plugin-firebase-crashlytics = "3.0.2"
 gradle-plugin-firebase-performance = "1.4.2"
@@ -42,6 +43,8 @@ compose-multiplatform = "1.7.0"
 
 # google libraries
 firebase_bom = "33.7.0"
+firebase-messaging-ktx = "24.1.0"
+firebase-database = "21.0.0"
 ksp = "2.0.21-1.0.27" # always match with kotlin version
 
 # saket
@@ -77,8 +80,7 @@ confetti = "2.0.5"
 updater = "2.1.0"
 google-inapp-reviews-ktx = "2.0.2"
 rich-text-editor = "1.0.0-rc10"
-firebase-messaging-ktx = "24.1.0"
-firebase-database = "21.0.0"
+buildconfig = "5.5.1"
 
 [libraries]
 # androidx
@@ -181,7 +183,6 @@ firebase-performance = { module = "com.google.firebase:firebase-perf-ktx" }
 firebase-inappmessagging = { module = "com.google.firebase:firebase-inappmessaging-display-ktx" }
 google-inapp-reviews-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "google-inapp-reviews-ktx" }
 
-
 # coil
 coil-kt = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
@@ -243,6 +244,7 @@ firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "
 firebase-performance = { id = "com.google.firebase.firebase-perf", version.ref = "gradle-plugin-firebase-performance" }
 google-services = { id = "com.google.gms.google-services", version.ref = "gradle-plugin-google-services" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 
 [bundles]
 android = [

--- a/modules-conventions/conventions/build.gradle.kts
+++ b/modules-conventions/conventions/build.gradle.kts
@@ -51,5 +51,12 @@ gradlePlugin {
             id = "bizilabs.convention.feature"
             implementationClass = "FeatureConventionPlugin"
         }
+        fun createPlugin(value: String, className: String) {
+            plugins.register(value) {
+                id = value
+                implementationClass = className
+            }
+        }
+        createPlugin("bizilabs.multiplatform.module", "conventions.MultiplatformModuleConvention")
     }
 }

--- a/modules-conventions/conventions/src/main/kotlin/FeatureConventionPlugin.kt
+++ b/modules-conventions/conventions/src/main/kotlin/FeatureConventionPlugin.kt
@@ -39,7 +39,7 @@ class FeatureConventionPlugin : Plugin<Project> {
                 implementation(libs.getLibrary("androidx-core-ktx"))
                 implementation(libs.getLibrary("androidx-appcompat"))
                 // coroutines
-                implementation(libs.getLibrary("kotlinx-coroutines"))
+                implementation(libs.getLibrary("kotlinx-coroutines-android"))
                 testImplementation(libs.getLibrary("kotlinx-coroutines-test"))
                 // voyager
                 implementation(libs.getBundle("voyager"))

--- a/modules-conventions/conventions/src/main/kotlin/ModuleConventionPlugin.kt
+++ b/modules-conventions/conventions/src/main/kotlin/ModuleConventionPlugin.kt
@@ -43,7 +43,7 @@ class ModuleConventionPlugin : Plugin<Project> {
                 // timber
                 implementation(libs.getLibrary("timber"))
                 // coroutines
-                implementation(libs.getLibrary("kotlinx-coroutines"))
+                implementation(libs.getLibrary("kotlinx-coroutines-android"))
                 testImplementation(libs.getLibrary("kotlinx-coroutines-test"))
                 // serialization
                 implementation(libs.getLibrary("kotlinx-serialization-json"))

--- a/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
+++ b/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
@@ -1,0 +1,102 @@
+package conventions
+
+import com.android.build.gradle.LibraryExtension
+import extensions.androidLibrary
+import extensions.getLibrary
+import extensions.getPlugin
+import extensions.multiplatform
+import extensions.plugins
+import org.gradle.api.JavaVersion
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+
+private fun KotlinMultiplatformExtension.configureIOS() {
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64()
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            isStatic = true
+        }
+    }
+}
+
+private fun KotlinMultiplatformExtension.configureAndroid() {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+}
+
+private fun KotlinMultiplatformExtension.sources(block: NamedDomainObjectContainer<KotlinSourceSet>.()-> Unit) {
+    sourceSets.block()
+}
+
+private fun LibraryExtension.configureAndroidLibrary() {
+    compileSdk = AndroidSdk.compileSdk
+    defaultConfig {
+        minSdk = AndroidSdk.compileSdk
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+class MultiplatformModuleConvention : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val catalogs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            // setup module plugins
+            plugins {
+                apply(catalogs.getPlugin("kotlin-multiplatform"))
+                apply(catalogs.getPlugin("android-library"))
+                apply(catalogs.getPlugin("kotlin-serialization"))
+                apply(catalogs.getPlugin("ktlint"))
+            }
+            // setup multiplatform
+            multiplatform {
+                configureAndroid()
+                configureIOS()
+                sources {
+                    commonMain.dependencies {
+                        implementation(catalogs.getLibrary("kotlinx-datetime"))
+                        implementation(catalogs.getLibrary("kotlinx-coroutines-core"))
+                        implementation(catalogs.getLibrary("kotlinx-serialization-json"))
+
+                    }
+                    commonTest.dependencies {
+                        implementation(catalogs.getLibrary("kotlinx-coroutines-test"))
+                    }
+                    androidMain.dependencies {
+                        implementation(catalogs.getLibrary("kotlinx-coroutines-android"))
+                    }
+                }
+            }
+            // setup android
+            androidLibrary {
+                configureAndroidLibrary()
+            }
+        }
+    }
+}

--- a/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
+++ b/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
@@ -2,6 +2,7 @@ package conventions
 
 import com.android.build.gradle.LibraryExtension
 import extensions.androidLibrary
+import extensions.getBundle
 import extensions.getLibrary
 import extensions.getPlugin
 import extensions.multiplatform
@@ -80,13 +81,20 @@ class MultiplatformModuleConvention : Plugin<Project> {
                 configureIOS()
                 sources {
                     commonMain.dependencies {
+                        // kotlinx
                         implementation(catalogs.getLibrary("kotlinx-datetime"))
                         implementation(catalogs.getLibrary("kotlinx-coroutines-core"))
                         implementation(catalogs.getLibrary("kotlinx-serialization-json"))
-
+                        // koin
+                        implementation(project.dependencies.platform(catalogs.getLibrary("koin-bom")))
+                        implementation(catalogs.getBundle("kmp-koin"))
                     }
                     commonTest.dependencies {
                         implementation(catalogs.getLibrary("kotlinx-coroutines-test"))
+                        // koin
+                        implementation(catalogs.getLibrary("koin-test"))
+                        implementation(catalogs.getLibrary("koin-test-junit4"))
+                        implementation(catalogs.getLibrary("koin-test-junit5"))
                     }
                     androidMain.dependencies {
                         implementation(catalogs.getLibrary("kotlinx-coroutines-android"))

--- a/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
+++ b/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
@@ -89,6 +89,8 @@ class MultiplatformModuleConvention : Plugin<Project> {
                         // koin
                         implementation(project.dependencies.platform(catalogs.getLibrary("koin-bom")))
                         implementation(catalogs.getBundle("kmp-koin"))
+                        // napier
+                        implementation(catalogs.getLibrary("napier"))
                     }
                     commonTest.dependencies {
                         implementation(catalogs.getLibrary("kotlinx-coroutines-test"))

--- a/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
+++ b/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
@@ -93,8 +93,6 @@ class MultiplatformModuleConvention : Plugin<Project> {
                         implementation(catalogs.getLibrary("kotlinx-coroutines-test"))
                         // koin
                         implementation(catalogs.getLibrary("koin-test"))
-                        implementation(catalogs.getLibrary("koin-test-junit4"))
-                        implementation(catalogs.getLibrary("koin-test-junit5"))
                     }
                     androidMain.dependencies {
                         implementation(catalogs.getLibrary("kotlinx-coroutines-android"))

--- a/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
+++ b/modules-conventions/conventions/src/main/kotlin/conventions/MultiplatformModuleConvention.kt
@@ -74,6 +74,7 @@ class MultiplatformModuleConvention : Plugin<Project> {
                 apply(catalogs.getPlugin("android-library"))
                 apply(catalogs.getPlugin("kotlin-serialization"))
                 apply(catalogs.getPlugin("ktlint"))
+                apply(catalogs.getPlugin("buildconfig"))
             }
             // setup multiplatform
             multiplatform {

--- a/modules-conventions/conventions/src/main/kotlin/extensions/ProjectExtensions.kt
+++ b/modules-conventions/conventions/src/main/kotlin/extensions/ProjectExtensions.kt
@@ -1,10 +1,15 @@
 package extensions
 
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.PluginManager
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal fun Project.configureAndroidCompose(
     commonExtension: CommonExtension<*, *, *, *, *>,
@@ -33,4 +38,20 @@ internal fun Project.configureAndroidCompose(
             androidTestImplementation(libs.getLibrary("compose-ui-test-junit4"))
         }
     }
+}
+
+internal fun Project.plugins(block: PluginManager.() -> Unit) {
+    with(pluginManager) { block() }
+}
+
+internal fun Project.multiplatform(block: KotlinMultiplatformExtension.() -> Unit) {
+    extensions.configure<KotlinMultiplatformExtension> { block() }
+}
+
+internal fun Project.androidLibrary(block: LibraryExtension.() -> Unit) {
+    extensions.configure<LibraryExtension> { block() }
+}
+
+internal fun Project.androidApplication(block: ApplicationExtension.() -> Unit) {
+    extensions.configure<ApplicationExtension> { block() }
 }

--- a/modules-conventions/conventions/src/main/kotlin/extensions/VersionCatalogsExtensions.kt
+++ b/modules-conventions/conventions/src/main/kotlin/extensions/VersionCatalogsExtensions.kt
@@ -2,7 +2,7 @@ package extensions
 
 import org.gradle.api.artifacts.VersionCatalog
 
-fun VersionCatalog.getVersion(alias: String) = this.findVersion(alias).get().toString()
+fun VersionCatalog.getPlugin(alias: String) = this.findPlugin(alias).get().get().pluginId
 
 fun VersionCatalog.getLibrary(alias: String) = this.findLibrary(alias).get()
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,8 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     includeBuild("modules-conventions/conventions")
     repositories {
+        gradlePluginPortal()
+        mavenCentral()
         google {
             content {
                 includeGroupByRegex("com\\.android.*")
@@ -9,15 +11,19 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
-        mavenCentral()
-        gradlePluginPortal()
     }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        google()
         mavenCentral()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
     }
 }
 
@@ -62,3 +68,9 @@ include(":modules-features:services")
 include(":modules-features:onboarding")
 include(":modules-features:reminders")
 include(":modules-features:reviews")
+
+// KMP module folders
+include(":shared-datasources")
+
+// KMP data sources modules
+include(":shared-datasources:remote")

--- a/shared-datasources/remote/build.gradle.kts
+++ b/shared-datasources/remote/build.gradle.kts
@@ -8,8 +8,11 @@ kotlin {
             // ktor
             implementation(libs.bundles.kmp.ktor)
             // supabase
-//            implementation(platform(libs.supabase.bom))
-//            implementation(libs.bundles.supabase)
+            implementation(project.dependencies.platform(libs.supabase.bom))
+            implementation(libs.bundles.supabase)
+        }
+        commonTest.dependencies {
+            implementation(libs.ktor.client.mock)
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)

--- a/shared-datasources/remote/build.gradle.kts
+++ b/shared-datasources/remote/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("bizilabs.multiplatform.module")
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            // ktor
+            implementation(libs.bundles.kmp.ktor)
+            // supabase
+//            implementation(platform(libs.supabase.bom))
+//            implementation(libs.bundles.supabase)
+        }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
+        }
+    }
+}
+
+android {
+    namespace = "com.bizilabs.streeek.lib.remote"
+}

--- a/shared-datasources/remote/src/commonMain/kotlin/com/bizilabs/streeek/lib/remote/RemoteModule.kt
+++ b/shared-datasources/remote/src/commonMain/kotlin/com/bizilabs/streeek/lib/remote/RemoteModule.kt
@@ -1,0 +1,3 @@
+package com.bizilabs.streeek.lib.remote
+
+class RemoteModule


### PR DESCRIPTION
## Description
Adds `shared-datasources` folder and `:shared-datasources:remote` module in preparation for migration, also adds new build convention

## Notes
The build convention is supposed to be reused across modules that have no UI implementation.
Also added a library for configuring [buildconfig](https://github.com/gmazzo/gradle-buildconfig-plugin) values

## Issues
closes #252