### PR TITLE
Ensures Already existing labels displayed and checked when user click…

### DIFF
--- a/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueLabelsSheet.kt
+++ b/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueLabelsSheet.kt
@@ -105,7 +105,7 @@ fun IssueScreenLabelsSheet(
                     is FetchListState.Success -> {
                         LazyColumn(modifier = Modifier.fillMaxWidth()) {
                             items(result.list) {
-                                val selected = state.labels.contains(it)
+                                val selected = (state.editIssue?.labels ?: emptyList()).union(state.labels).toList().contains(it)
                                 Card(
                                     onClick = { onClickAddLabel(it) },
                                     colors =

--- a/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueScreenCreateSection.kt
+++ b/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueScreenCreateSection.kt
@@ -1,6 +1,7 @@
 package com.bizilabs.streeek.feature.issue.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -83,7 +84,13 @@ fun IssueScreenCreateSection(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(16.dp),
+                modifier =
+                    Modifier
+                        .padding(16.dp)
+                        .clickable(
+                            onClick =
+                            onClickOpenLabels,
+                        ),
                 text = "Labels",
             )
             LazyRow(

--- a/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueScreenEditSection.kt
+++ b/modules-features/issue/src/main/java/com/bizilabs/streeek/feature/issue/components/IssueScreenEditSection.kt
@@ -1,6 +1,7 @@
 package com.bizilabs.streeek.feature.issue.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -104,7 +105,13 @@ fun IssueScreenEditSection(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                modifier = Modifier.padding(16.dp),
+                modifier =
+                    Modifier
+                        .padding(16.dp)
+                        .clickable(
+                            onClick =
+                            onClickOpenLabels,
+                        ),
                 text = "Labels",
             )
             LazyRow(


### PR DESCRIPTION
## Description
> information of what was being worked on (__if necessary__)

- Ensures Already existing labels displayed and checked when user clicks on labels drop down

## Notes
- You can now pull labels drop down by clicking the. "Labels" label
- Editing an issue  now highlights already existing labels

## Issues
> issue number of what was being worked on (__if necessary__)

Closes #272  #271 

## Screenshots


https://github.com/user-attachments/assets/01478e02-54de-452b-b732-cf1e85b76a80

