### PR TITLE
Update update-contributors.yml

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,6 +11,7 @@ jobs:
     # Grant write access for the workflow to update repo with Streeekers
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Update Contributors List


### PR DESCRIPTION
## Description
This PR allows the github action to create a PR to update main with contributors since main is a protected branch that cannot be updated directly

## Notes
None

## Issues
None

### Screenshot
None
